### PR TITLE
Update tenant template - add sales and revenue receiving address

### DIFF
--- a/src/typeSpecs/EventTenant.js
+++ b/src/typeSpecs/EventTenant.js
@@ -72,6 +72,18 @@ const eventTenantSpec = {
           "type": "list"
         },
         {
+          "hint": "Wallet or contract address for receiving store revenue",
+          "label": "Sales Revenue Address",
+          "name": "revenue_addr",
+          "type": "text"
+        },
+        {
+          "hint": "Wallet or contract address for receiving royalties revenue",
+          "label": "Royalty Revenue Address",
+          "name": "royalty_addr",
+          "type": "text"
+        },
+        {
           "hint": "Default royalty percentage for NFT transactions",
           "label": "Royalty",
           "name": "royalty",


### PR DESCRIPTION
Tenants can configure an address (either wallet or a contact) for receiving primary and another address for secondary sales.  These addresses can be the same.

The initial version of the revenue receiver contract - https://github.com/eluv-io/contracts-evm/pull/14