### PR TITLE
Update tenant and nft template spec:

### DIFF
--- a/src/typeSpecs/EventTenant.js
+++ b/src/typeSpecs/EventTenant.js
@@ -94,32 +94,6 @@ const eventTenantSpec = {
           "label": "Minimum Listing Price",
           "name": "min_list_price",
           "type": "number"
-        },
-        {
-          "fields": [
-            {
-              "hint": "Without checking this box token IDs will be assigned arbitrarily.  If checked, token IDs will be ordinals starting at #1",
-              "label": "Use mint ordinal as token ID",
-              "name": "use_mint_ordinal_in_token_id",
-              "type": "checkbox"
-            },
-            {
-              "hint": "If checked, token IDs will be shuffled using a specified 'seed', instead of being minted in order #1, #2, ...",
-              "label": "Shuffle token ID when minting",
-              "name": "shuffle_token_id",
-              "type": "checkbox"
-            },
-            {
-              "hint": "Used to personalize the deterministic random shuffle of mint token IDs",
-              "label": "Shuffle seed phrase",
-              "name": "shuffle_seed",
-              "type": "text"
-            }
-          ],
-          "hint": "Default minting parameters (can be overridden per token)",
-          "label": "Mint Parameters",
-          "name": "minter",
-          "type": "subsection"
         }
       ],
       "hint": "Tenant-level settings for fungible/non-fungible tokens",

--- a/src/typeSpecs/NFTTemplate.js
+++ b/src/typeSpecs/NFTTemplate.js
@@ -41,7 +41,8 @@ const NFTTemplateSpec = {
       "fields": [
         {
           "name": "address",
-          "type": "text"
+          "type": "text",
+          "readonly": true
         }
       ]
     },
@@ -53,37 +54,26 @@ const NFTTemplateSpec = {
       "no_localize": true,
       "fields": [
         {
-          "name": "merge_meta",
-          "label": "Merge Metadata",
-          "type": "json"
-        },
-        {
-          "name": "token_template",
-          "label": "Token ID Template",
-          "type": "text"
-        },
-        {
-          "name": "cauth_id",
-          "label": "Mint Key ID",
-          "type": "text"
-        },
-        {
-          "name": "fauth_id",
-          "label": "Fabric Key ID",
-          "type": "text"
-        },
-        {
           "name": "use_mint_ordinal_in_token_id",
           "label": "Use Mint Ordinal in Token ID",
           "type": "checkbox",
+          "hint": "Generate numeric token IDs: #1, #2, #3, ... (initial mint order may be randomized)",
           "default_value": true
         },
         {
           "name": "shuffle_token_id",
           "label": "Shuffle Token ID",
           "type": "checkbox",
+          "hint": "When using ordinal token IDs, randomize the initial mint order",
           "default_value": true
-        }
+        },
+        {
+          "name": "token_template",
+          "label": "Token ID Template",
+          "type": "text",
+          "hint": "Create vanity token IDs based on this template (only valid if not using ordinal token IDs)"
+        },
+
       ]
     },
     {
@@ -186,16 +176,20 @@ const NFTTemplateSpec = {
           "name": "address",
           "label": "NFT Contract Address",
           "type": "text",
-          "no_localize": true
-        },
-        {
-          "name": "edition_name",
-          "type": "text"
+          "no_localize": true,
+          "hint": "Address of the NFT contract associated with this NFT template (read-only - set by the NFT build)",
+          "readonly": true
         },
         {
           "name": "total_supply",
           "type": "integer",
-          "no_localize": true
+          "no_localize": true,
+          "hint": "Maximum number of tokens that can be generated for this NFT contract (read-only - this number is read from the contract)",
+          "readonly": true
+        },
+        {
+          "name": "edition_name",
+          "type": "text"
         },
         {
           "name": "creator",
@@ -461,6 +455,17 @@ const NFTTemplateSpec = {
               "name": "is_openable",
               "type": "checkbox",
               "no_localize": true
+            },
+            {
+              "name": "pack_generator",
+              "type": "select",
+              "default_value": "random",
+              "options": [
+                "random",
+                "preset"
+              ],
+              "no_localize": true,
+              "hint": "Choose the way pack content will be generated.  Use 'preset' if content supply is limited to the number of packs and distribution needs to be precise."
             },
             {
               "name": "open_button_text",


### PR DESCRIPTION
- remove tenant mint parameters (shuffle, token ID as ordinal, ...) - these will be set on the NFT template directly
- set NFT contract fields read only
- add pack generator option

Tested locally:

### New NFT pack generation option:

<img width="815" alt="image" src="https://user-images.githubusercontent.com/29080995/229988937-bf599810-e6f5-4766-80d5-43aed0dd7474.png">

### NFT template contract info read only:

<img width="691" alt="image" src="https://user-images.githubusercontent.com/29080995/229989050-78058968-f99b-47a9-81ee-d0f4400cbabb.png">

###Tenant configuration - simplified (removed shuffle config):

<img width="815" alt="image" src="https://user-images.githubusercontent.com/29080995/229989277-c438aa1a-39bc-4ea9-b2b8-258860efe802.png">



