### PR TITLE
Allow setting empty form values, do not encode empty string

### DIFF
--- a/src/components/Inputs.js
+++ b/src/components/Inputs.js
@@ -122,6 +122,8 @@ const InitializeField = ({fields, defaultValue}) => {
 };
 
 const SHA512 = async (str) => {
+  if(!str) { return ""; }
+
   const buf = await crypto.subtle.digest("SHA-512", new TextEncoder("utf-8").encode(str));
   return Array.prototype.map.call(new Uint8Array(buf), x=>(("00"+x.toString(16)).slice(-2))).join("");
 };
@@ -131,7 +133,7 @@ export const PasswordInput = ({label, name, value, onChange, hidden=false, requi
   if(hidden) { return null; }
 
   const [locked, setLocked] = useState(!!value);
-  const [password, setPassword] = useState("");
+  const [password, setPassword] = useState(value || "");
 
   return (
     <div className={`-elv-input password-input ${className}`}>

--- a/src/components/Inputs.js
+++ b/src/components/Inputs.js
@@ -158,7 +158,13 @@ export const PasswordInput = ({label, name, value, onChange, hidden=false, requi
           className="-elv-input password-input__input"
         />
         <button
-          onClick={() => setLocked(!locked)}
+          onClick={() => {
+            setLocked(!locked);
+            if(locked) {
+              setPassword("");
+              onChange("");
+            }
+          }}
           className="password-input__lock-button"
         >
           <ImageIcon label={locked ? "Unlock Password Field" : "Lock Password Field"} icon={locked ? LockIcon : UnlockIcon} />

--- a/src/stores/Form.js
+++ b/src/stores/Form.js
@@ -1657,12 +1657,11 @@ class FormStore {
         return;
       }
 
-      if(!newValue) {
-        newMetadata[key] = existingValue;
-      }
 
       if(typeof newValue === "object" && typeof existingValue === "object") {
         newMetadata[key] = this.MergeExistingMetadata(existingValue, newValue);
+      } else {
+        newMetadata[key] = newValue;
       }
     });
 

--- a/src/stores/Form.js
+++ b/src/stores/Form.js
@@ -1657,11 +1657,12 @@ class FormStore {
         return;
       }
 
+      if(newValue === undefined) {
+        newMetadata[key] = existingValue;
+      }
 
       if(typeof newValue === "object" && typeof existingValue === "object") {
         newMetadata[key] = this.MergeExistingMetadata(existingValue, newValue);
-      } else {
-        newMetadata[key] = newValue;
       }
     });
 


### PR DESCRIPTION
Password field and other fields are not updating when trying to set an empty value. Change so that the new value takes precedence. Also return an empty string when passing an empty string to `SHA512()`.