### PR TITLE
Check existence of assetInfo props in object when saving

### DIFF
--- a/src/stores/Form.js
+++ b/src/stores/Form.js
@@ -1705,7 +1705,7 @@ class FormStore {
         // Move built-in fields to top level info
         ["title", "display_title", "ip_title_id", "slug", "title_type", "asset_type"]
           .forEach(attr => {
-            if(localizedData.assetInfo[attr]) {
+            if((localizedData.assetInfo || {}).hasOwnProperty(attr)) {
               topInfo[attr] = localizedData.assetInfo[attr];
             }
           });


### PR DESCRIPTION
Allow saving empty asset info values