### PR TITLE
Change searchable link default value

### DIFF
--- a/src/typeSpecs/Default.js
+++ b/src/typeSpecs/Default.js
@@ -77,7 +77,7 @@ const defaultSpec = {
   ],
   searchable_links: [
     {target: "/public/asset_metadata", link_key: "asset_metadata"},
-    {target: "/public/assets", link_key: "assets"},
+    {target: "/assets", link_key: "assets"},
     {target: "/offerings", link_key: "offerings"},
     {target: "/video_tags", link_key: "video_tags"}
   ]


### PR DESCRIPTION
This is used when loading a Default profile in asset manager.