### PR TITLE
Fix slug read-only bug

### DIFF
--- a/src/stores/Form.js
+++ b/src/stores/Form.js
@@ -1602,7 +1602,8 @@ class FormStore {
     const promises = [];
 
     for(let asset of assets || []) {
-      const {displayTitle, versionHash, isDefault, isSigned, slug, authContainerId, originalLink={}} = asset;
+      const {displayTitle, versionHash, isDefault, isSigned, authContainerId, originalLink={}} = asset;
+      let {slug} = asset;
         if(isSigned) {
           if(!originalLink.hasOwnProperty(".")) {
             originalLink["."] = {};


### PR DESCRIPTION
The `slug` property is not being reassigned since it's read-only. Change to `let`.
Relates to #46 