### PR TITLE
Fix field name open_id

### DIFF
--- a/src/typeSpecs/EventTenant.js
+++ b/src/typeSpecs/EventTenant.js
@@ -113,7 +113,7 @@ const eventTenantSpec = {
       ],
       "hint": "Specify a custom OpenID provider for use with the Eluvio Custodial Wallet",
       "label": "Custom OpenID",
-      "name": "openid",
+      "name": "open_id",
       "type": "subsection"
     }
   ],


### PR DESCRIPTION
We had an inconsistency in naming the field `open_id` vs `openid`
The correct option is `open_id`